### PR TITLE
move _has_redbot condition check under __init__

### DIFF
--- a/TagScriptEngine/adapter/redbotadapters.py
+++ b/TagScriptEngine/adapter/redbotadapters.py
@@ -23,12 +23,12 @@ __all__: Tuple[str, ...] = ("RedCommandAdapter", "RedBotAdapter")
 
 
 class RedCommandAdapter(SimpleAdapter["Command"]):
-    if not _has_redbot:
-        raise ImportError("A Red-DiscordBot instance is required to use this.", name="redbot")
-
     def __init__(self, base: Command, *, signature: Optional[str] = None) -> None:
         super().__init__(base=base)
         self.signature: Optional[str] = signature
+
+        if not _has_redbot:
+            raise ImportError("A Red-DiscordBot instance is required to use this.", name="redbot")
 
     def update_attributes(self) -> None:
         command: Command = self.object


### PR DESCRIPTION
Class-level statements are executed when the class is defined, which will result in ImportError when RedCommandAdapter is defined despite redbot being optional. This moves the check under \_\_init\_\_ to prevent the same

edit: escaped markdown